### PR TITLE
bug fix : do not write the datasets to cache automatically

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -251,7 +251,7 @@ class Dataset(Directory):
         with open(self._info_fname, mode='w') as outfile:
                 yaml.dump(self._data, outfile,
                           default_flow_style=False)
-        return self._data
+        return self._data  
             
     #----------------------------------------------------------------------
     def _read_yaml(self, fname=None):

--- a/dataset.py
+++ b/dataset.py
@@ -94,8 +94,8 @@ class Dataset(Directory):
             self._jobtype = self._guess_jobtype()
             self._find_mother()
             self._aggregate_yaml()
-            self._write_to_cache()
-            self.write_yaml()
+            # self._write_to_cache()
+            # self.write_yaml()
 
     #----------------------------------------------------------------------
     def _analyze_cfg(self, cfgname):
@@ -225,7 +225,14 @@ class Dataset(Directory):
         return self._mother
 
     #----------------------------------------------------------------------
-    def write_yaml(self):
+    def write(self):
+        """"""
+        self._write_to_cache()
+        self._write_yaml()
+        
+
+    #----------------------------------------------------------------------
+    def _write_yaml(self):
         '''write the yaml file'''
         self._data['sample'] = {
             'name': self.name,
@@ -279,6 +286,7 @@ class Dataset(Directory):
         
     #----------------------------------------------------------------------
     def _write_to_cache(self):
+        print 'WRITE TO CACHE'
         cache = basedir.abscache(self.name)
         if not os.path.isdir(cache):
             os.makedirs(cache)

--- a/fcc_component.py
+++ b/fcc_component.py
@@ -7,10 +7,10 @@ class FCCComponent(cfg.MCComponent):
     def __init__(self, name, pattern='*.root', cache=True,
                  cfg=None, xsection=None, **kwargs):
         """"""
-        self.dataset = Dataset(name, pattern, cache, cfg, xsection)
+        dataset = Dataset(name, pattern, cache, cfg, xsection)
         super(FCCComponent, self).__init__(
-            self.dataset.name,
-            self.dataset.list_of_good_files(),
-            xSection=self.dataset.xsection(), 
+            dataset.name,
+            dataset.list_of_good_files(),
+            xSection=dataset.xsection(), 
             **kwargs
         )

--- a/test_dataset.py
+++ b/test_dataset.py
@@ -55,7 +55,7 @@ class TestFccswDataset(unittest.TestCase):
     def test_4_yaml(self):
         """Test that the yaml file can be written and read."""
         dataset = Dataset(dataset_name_fccsw, cache=cache)
-        data_written = dataset.write_yaml()
+        data_written = dataset._write_yaml()
         data_read = dataset._read_yaml()
         self.assertDictEqual(data_written, data_read)
         
@@ -72,6 +72,7 @@ class TestFccswDataset(unittest.TestCase):
         dataset = Dataset(dataset_name_fccsw, xsection=1, cache=True)
         self.assertEqual(dataset.uid(), self.dataset.uid())
         self.assertEqual(dataset.xsection(), 1)
+        dataset.write()
         dataset = Dataset(dataset_name_fccsw, cache=True)
         self.assertEqual(dataset.xsection(), 1)
     
@@ -122,7 +123,7 @@ class TestHeppyDataset(unittest.TestCase):
         """Test that the yaml file can be written and read."""
         dataset = Dataset(dataset_name_heppy, dataset_pattern_heppy, 
                           cache=cache)
-        data_written = dataset.write_yaml()
+        data_written = dataset._write_yaml()
         data_read = dataset._read_yaml()
         self.assertDictEqual(data_written, data_read)
         


### PR DESCRIPTION
writing the dataset to cache automatically was leading to an issue of concurrent write when processing the dataset in parallel on the batch. The datasets are now written to cache when the write method is called (eg. in publish.py), and not everytime the dataset constructor is called